### PR TITLE
Add jvm*-server.options files to the resulting CassandraDatacenter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/atomicgo/cursor v0.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/burmanm/definitions-parser v0.0.0-20220830093729-83928cf5eb13 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 // indirect
 	github.com/charmbracelet/lipgloss v0.5.0 // indirect
@@ -204,3 +205,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/burmanm/definitions-parser => /Users/michael.burman/projects/datastax/config-definitions-parser

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembj
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/burmanm/definitions-parser v0.0.0-20220830093729-83928cf5eb13 h1:tWZ8/SWxstyVVibvzevV9Lgb+jn15+hJnQibZ4JUNaM=
+github.com/burmanm/definitions-parser v0.0.0-20220830093729-83928cf5eb13/go.mod h1:jSsFX7C4chX5kyf94+U0YgKC5cLKjy35UG4/zo8Owng=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/migrate/commit.go
+++ b/pkg/migrate/commit.go
@@ -147,14 +147,14 @@ func (c *MigrateFinisher) createCassandraDatacenter() error {
 		return err
 	}
 
-	cassandraYaml := configFilesMap.Data["cassandra-yaml"]
-	modelValues := make(map[string]interface{})
-	if err := yaml.Unmarshal([]byte(cassandraYaml), modelValues); err != nil {
-		return err
-	}
+	config := make(map[string]interface{})
 
-	config := map[string]interface{}{
-		"cassandra-yaml": modelValues,
+	for yamlKey, yamlFile := range configFilesMap.Data {
+		modelValues := make(map[string]interface{})
+		if err := yaml.Unmarshal([]byte(yamlFile), modelValues); err != nil {
+			return err
+		}
+		config[yamlKey] = modelValues
 	}
 
 	modelBytes, err := json.Marshal(config)

--- a/pkg/migrate/config_test.go
+++ b/pkg/migrate/config_test.go
@@ -13,8 +13,12 @@ func TestConfigParsing(t *testing.T) {
 	parser := NewParser(confDir)
 	err := parser.ParseConfigs()
 
-	require.Equal(2, len(parser.yamls))
+	require.Equal(4, len(parser.yamls))
 	require.NoError(err)
+
+	require.Equal(1, len(parser.yamls["jvm11-server-options"]))
+	addJvmOptions := parser.yamls["jvm11-server-options"]["additional-jvm-options"].([]string)
+	require.Equal(12, len(addJvmOptions))
 }
 
 func TestParseDataPaths(t *testing.T) {


### PR DESCRIPTION
Parsed with the definitions-parser, this makes the jvm*-server.options keys cass-config-builder formatted.